### PR TITLE
refactor: rewrite the parser to have idiomatic ts-morph code

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type CreateIntlWatcherOptions = {
 	 */
 	sourceDirectory?: string
 	/**
-	 * File path to the tsconfig.json used to deduce which files to scan.
+	 * File path to the tsconfig.json used to deduce which files to scan. Defaults to 'tsconfig.json'.
 	 */
 	tsConfigFilePath?: string
 }


### PR DESCRIPTION
Replaces references to underlying `ts` compiler nodes and uses the actual `ts-morph` API for once.